### PR TITLE
force fds chr style to external counts

### DIFF
--- a/R/mergeExternalData.R
+++ b/R/mergeExternalData.R
@@ -69,6 +69,7 @@ mergeExternalData <- function(fds, countFiles, sampleIDs, annotation=NULL){
     extCts <- lapply(reqNames, function(id){
         gr <- makeGRangesFromDataFrame(fread(countFiles[id]),
                 keep.extra.columns=TRUE)
+        seqlevelsStyle(gr) <- seqlevelsStyle(fds) #force fds style onto external counts
         if(any(!sampleIDs %in% colnames(mcols(gr)))){
             stop("Can not find provided sampleID in count data. Missing IDs: ",
                     paste(collapse=", ",


### PR DESCRIPTION
If the chromosome styles of the local files do not match the style of the external files, there is a merging error. [see here: DROP #295](https://github.com/gagneurlab/drop/issues/295)

This forces the style of the external samples to match the local samples
