### PR TITLE
Adapt result table format from long to wide for FDR subset results

### DIFF
--- a/R/plotMethods.R
+++ b/R/plotMethods.R
@@ -286,16 +286,13 @@
 #' 
 #' # other ways to call these plotting functions
 #' plotExpression(fds, idx=10, sampleID="sample1", type="jaccard")
-#' plotExpression(fds, result=res[FDR_set == "testSet",][1], 
-#'                  subsetName="testSet")
+#' plotExpression(fds, result=res[1], subsetName="testSet")
 #' plotQQ(fds, idx=10, sampleID="sample1", type="jaccard")
-#' plotQQ(fds, result=res[FDR_set == "testSet",][1], subsetName="testSet")
+#' plotQQ(fds, result=res[1], subsetName="testSet")
 #' plotExpectedVsObservedPsi(fds, idx=10, sampleID="sample1", type="jaccard")
-#' plotExpectedVsObservedPsi(fds, result=res[FDR_set == "testSet",][1], 
-#'                  subsetName="testSet")
+#' plotExpectedVsObservedPsi(fds, result=res[1], subsetName="testSet")
 #' plotSpliceMetricRank(fds, idx=10, sampleID="sample1", type="jaccard")
-#' plotSpliceMetricRank(fds, result=res[FDR_set == "testSet",][1], 
-#'                  subsetName="testSet")
+#' plotSpliceMetricRank(fds, result=res[1], subsetName="testSet")
 #' 
 #' # create manhattan plot of pvalues by genomic position
 #' if(require(ggbio)){
@@ -819,7 +816,7 @@ plotExpectedVsObservedPsi <- function(fds, type=fitMetrics(fds),
 
     if(is.null(colGroup)){
         g <- g + scale_colour_manual(
-            values=c("FALSE"="gray70", "TRUE"="firebrick"))
+            values=c("gray70", "firebrick"))
     }
     
     plotBasePlot(g, basePlot)

--- a/man/plotFunctions.Rd
+++ b/man/plotFunctions.Rd
@@ -558,16 +558,13 @@ plotSpliceMetricRank(fds, res=res[1])
 
 # other ways to call these plotting functions
 plotExpression(fds, idx=10, sampleID="sample1", type="jaccard")
-plotExpression(fds, result=res[FDR_set == "testSet",][1], 
-                 subsetName="testSet")
+plotExpression(fds, result=res[1], subsetName="testSet")
 plotQQ(fds, idx=10, sampleID="sample1", type="jaccard")
-plotQQ(fds, result=res[FDR_set == "testSet",][1], subsetName="testSet")
+plotQQ(fds, result=res[1], subsetName="testSet")
 plotExpectedVsObservedPsi(fds, idx=10, sampleID="sample1", type="jaccard")
-plotExpectedVsObservedPsi(fds, result=res[FDR_set == "testSet",][1], 
-                 subsetName="testSet")
+plotExpectedVsObservedPsi(fds, result=res[1], subsetName="testSet")
 plotSpliceMetricRank(fds, idx=10, sampleID="sample1", type="jaccard")
-plotSpliceMetricRank(fds, result=res[FDR_set == "testSet",][1], 
-                 subsetName="testSet")
+plotSpliceMetricRank(fds, result=res[1], subsetName="testSet")
 
 # create manhattan plot of pvalues by genomic position
 if(require(ggbio)){

--- a/tests/testthat/test_plotSampleResults.R
+++ b/tests/testthat/test_plotSampleResults.R
@@ -35,6 +35,14 @@ test_that("Results function", {
     expect_equal(res_gene_signif[type == "psi3", .N], 2)
     expect_equal(res_gene_signif[type == "theta", .N], 3)
     
+    # results on subset of genes during FDR
+    geneList <- list('sample1'=c("TIMMDC1"), 'sample2'=c("MCOLN1"))
+    fds <- calculatePadjValues(fds, type="jaccard", 
+                     subsets=list("exampleSubset"=geneList))
+    expect_equal(length(results(fds, all=TRUE, psiType="jaccard")), 
+                prod(dim(fds)))
+    expect_error(results(fds, all=TRUE, psiType="psi5"))
+    
 })
 
 test_that("Main plotting function", {


### PR DESCRIPTION
- Adds a column 'padjust_subsetName' (or  'padjustGene_subsetName') for the result of FDR on the subset only, instead of reporting it in a separate row.
- Adapts code in examples of plot functions accordingly.
- Adds a test case for the behavior of the results function with FDR values from gene subsets.