### PR TITLE
github actions fix

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -323,7 +323,7 @@ jobs:
         ## https://seandavi.github.io/BuildABiocWorkshop/articles/HOWTO_BUILD_WORKSHOP.html#6-add-secrets-to-github-repo
         ## Check https://github.com/docker/build-push-action/tree/releases/v1
         ## for more details.
-      - uses: docker/build-push-action@v1
+      - uses: docker/build-push-action@v6
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && runner.os == 'Linux' "
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/tests/testthat/test_plotSampleResults.R
+++ b/tests/testthat/test_plotSampleResults.R
@@ -30,10 +30,10 @@ test_that("Results function", {
     res_gene_signif <- results(fds, aggregate=TRUE, all=FALSE,
                           padjCutoff=NA, deltaPsiCutoff=0.01)
     res_gene_signif <- as.data.table(res_gene_signif)
-    expect_equal(res_gene_signif[type == "jaccard", .N], 1)
-    expect_equal(res_gene_signif[type == "psi5", .N], 3)
-    expect_equal(res_gene_signif[type == "psi3", .N], 3)
-    expect_equal(res_gene_signif[type == "theta", .N], 2)
+    expect_equal(res_gene_signif[type == "jaccard", uniqueN(paste(seqnames, start, end))], 1)
+    expect_equal(res_gene_signif[type == "psi5", uniqueN(paste(seqnames, start, end))], 3)
+    expect_equal(res_gene_signif[type == "psi3", uniqueN(paste(seqnames, start, end))], 3)
+    expect_equal(res_gene_signif[type == "theta", uniqueN(paste(seqnames, start, end))], 2)
     
     # results on subset of genes during FDR
     geneList <- list('sample1'=c("TIMMDC1"), 'sample2'=c("MCOLN1"))


### PR DESCRIPTION
- [Update docker/build-push-action to v6](https://github.com/gagneurlab/FRASER/commit/4fc3b2e7c6c56032303fc132c13d902f6cd0e087)
- Some junctions can be annotated by two genes. In tests, [only check number of unique junctions instead](https://github.com/gagneurlab/FRASER/commit/f0598e54496326f6f1008db20db355056ab0f7fc)